### PR TITLE
Ruby 1.9 compatibility

### DIFF
--- a/lib/scheduler_daemon/base.rb
+++ b/lib/scheduler_daemon/base.rb
@@ -119,7 +119,7 @@ module Scheduler
       tasks_to_run.each{|f|
         begin
           unless options[:only].any? && options[:only].all?{|m| f !~ Regexp.new(Regexp.escape(m)) }
-            require f
+            require "./#{f}"
             filename = f.split('/').last.split('.').first
             log "Loading task #{filename}..."
             @tasks << filename.camelcase.constantize # "path/newsfeed_task.rb" => NewsfeedTask


### PR DESCRIPTION
These two commits make it compatible with ruby 1.9.

There is probably a better way to do this, like being able to specify the rails root, and appending that instead of "./"
