### PR TITLE
fixes issue with template not found because of root_path

### DIFF
--- a/lib/scheduler_daemon/rails/generators/scheduler_task/scheduler_task_generator.rb
+++ b/lib/scheduler_daemon/rails/generators/scheduler_task/scheduler_task_generator.rb
@@ -6,6 +6,10 @@ class SchedulerTaskGenerator < Rails::Generators::NamedBase
     readme(File.join(template_dir, 'README'))
   end
   
+  def self.source_root
+    File.dirname(File.expand_path(__FILE__))
+  end
+  
   private
     def source_dir
       File.join(template_dir, 'scheduled_tasks')


### PR DESCRIPTION
This fixes issue #8 

The current version generates the following error message when trying to generate a scheduled task from templates

Could not find "/home/andi/.rvm/gems/ruby-1.9.3-p0@taclom/gems/scheduler_daemon-1.1.2/lib/scheduler_daemon/rails/generators/scheduler_task/templates/scheduled_tasks/example_task.rb" in any of your source paths. Please invoke SchedulerTaskGenerator.source_root(PATH) with the PATH containing your templates. Currently you have no source paths.
