### PR TITLE
Allow log_dir option to be given to Daemons.run

### DIFF
--- a/bin/scheduler_daemon
+++ b/bin/scheduler_daemon
@@ -44,7 +44,8 @@ app_args[:pid_dir] ||= File.expand_path(File.join(app_args[:dir], 'log'))
 app_args[:log_dir] ||= File.expand_path(File.join(app_args[:dir], 'log'))
 scheduler = File.join(File.dirname(__FILE__), %w(.. lib loader scheduler_loader.rb))
 
-raise "#{pid_dir} does not exist" unless File.exist?(app_args[:pid_dir])
+raise "#{app_args[:pid_dir]} does not exist" unless File.exist?(app_args[:pid_dir])
+raise "#{app_args[:log_dir]} does not exist" unless File.exist?(app_args[:log_dir])
 
 app_options = {
   :app_name => 'scheduler_daemon',


### PR DESCRIPTION
Utilizes the `:log_dir` option of the [Daemons](http://daemons.rubyforge.org/classes/Daemons.html) gem to allow users to place their pid files in a separate directory than their log files.

For example, you can now launch scheduler_daemon as such:

`bundle exec scheduler_daemon start -- --pid_dir=tmp/pids --log_dir=log/`
