### PR TITLE
Remove circular dependency

### DIFF
--- a/scheduler_daemon.gemspec
+++ b/scheduler_daemon.gemspec
@@ -53,7 +53,6 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<scheduler_daemon>.freeze, [">= 0"])
   s.add_development_dependency(%q<rspec>.freeze, ["~> 3.12.0"])
   s.add_runtime_dependency(%q<activesupport>.freeze, [">= 0"])
   s.add_runtime_dependency(%q<eventmachine>.freeze, [">= 0.12.8"])


### PR DESCRIPTION
Fixes #33 

The gem should not depend on itself. This causes installation to fail:

```
% gem install scheduler_daemon:1.1.6
ERROR:  While executing gem ... (Gem::Resolver::Molinillo::CircularDependencyError)
    There is a circular dependency between scheduler_daemon
```